### PR TITLE
feat!: add file scheme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,22 @@
+## 0.3.0 (2024-04-29)
 
-## 0.1.0 (2023-09-27)
+Major change in query format. `library` is no longer a provider setting, and the `mssp://` 
+scheme is introduced and required for all queries. Also comes with better tests for the 
+query validation, and improved documentation.
+
+## 0.2.4 (2024-04-29)
+
+First release on PyPI
+
+## 0.2.1 & 0.2.2 (2024-04-29)
+
+Fixes for GitHub actions on releases
+
+## 0.2.0 (2024-04-29)
+
+Decoupled from [snakemake-storage-plugin-http](https://github.com/snakemake/snakemake-storage-plugin-http/) 
+and cleaned up project structure.
+
+## 0.1.0 (2024-04-26)
 
 First version based on the original ([snakemake-storage-plugin-http](https://github.com/snakemake/snakemake-storage-plugin-http/))

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
 # snakemake-storage-plugin-sharepoint
 
-Snakemake storage plugin for reading and writing files on Microsoft SharePoint.
+[Snakemake](https://snakemake.github.io/) storage plugin for reading and writing files
+on Microsoft SharePoint sites.
+Documentation is on the snakemake plugin catalog:
+https://snakemake.github.io/snakemake-plugin-catalog/plugins/storage/sharepoint.html

--- a/docs/further.md
+++ b/docs/further.md
@@ -1,5 +1,7 @@
-For now, the `site_url` and `library` settings are required settings on the storage provider.
-This is because the URL to a document cannot uniquely be parsed into the separate components.
+For now, the `site_url` setting is a required setting on the storage provider.
+This is because the URL to a document cannot uniquely be parsed into the separate components
+necessary for downloading and uploading on SharePoint (which are: site collection, library, 
+and filename).
 
 Also, overwriting files on SharePoint is disabled by default, and needs to be enabled on the 
 storage provider using the `allow_overwrite` setting.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "snakemake-storage-plugin-sharepoint"
-version = "0.2.4"
+version = "0.3.0"
 description = "Snakemake storage plugin for reading and writing files on Microsoft SharePoint."
 authors = [
     "Hugo Lapre <hugo.lapre@brabantwater.nl>",

--- a/snakemake_storage_plugin_sharepoint/provider.py
+++ b/snakemake_storage_plugin_sharepoint/provider.py
@@ -41,10 +41,27 @@ class StorageProvider(StorageProviderBase):
         """Return an example query with description for this storage provider."""
         return [
             ExampleQuery(
-                query="mssp://library/folder/file.txt",
-                description="A file URL in a SharePoint library.",
+                query="mssp://Documents/data.csv",
+                description=(
+                    "A file `data.csv` in a SharePoint library called `Documents`."
+                ),
                 type=QueryType.INPUT,
-            )
+            ),
+            ExampleQuery(
+                query="mssp://library/folder/file.txt",
+                description=(
+                    "A file `file.txt` in a folder named `folder` under a "
+                    "SharePoint library called `library`."
+                ),
+                type=QueryType.INPUT,
+            ),
+            ExampleQuery(
+                query="mssp://Documents/output.csv",
+                description=(
+                    "A file `target.csv` in a SharePoint library called `Documents`."
+                ),
+                type=QueryType.OUTPUT,
+            ),
         ]
 
     def default_max_requests_per_second(self) -> float:

--- a/snakemake_storage_plugin_sharepoint/provider.py
+++ b/snakemake_storage_plugin_sharepoint/provider.py
@@ -60,17 +60,32 @@ class StorageProvider(StorageProviderBase):
     def is_valid_query(cls, query: str) -> StorageQueryValidationResult:
         try:
             parsed = urlparse(query)
+            scheme = parsed.scheme
+            library = parsed.netloc
+            filepath = parsed.path.lstrip("/")
         except Exception as e:
             return StorageQueryValidationResult(
                 query=query,
                 valid=False,
                 reason=f"cannot be parsed as URL ({e})",
             )
-        if not parsed.scheme == "mssp":
+        if not scheme == "mssp":
             return StorageQueryValidationResult(
                 query=query,
                 valid=False,
                 reason="scheme must be 'mssp'",
+            )
+        if library == "":
+            return StorageQueryValidationResult(
+                query=query,
+                valid=False,
+                reason="library must be specified (e.g. mssp://library/file.txt)",
+            )
+        if filepath == "":
+            return StorageQueryValidationResult(
+                query=query,
+                valid=False,
+                reason="path must specify the library and file path (e.g. mssp://library/file.txt or mssp://library/folder/file.txt)",
             )
         return StorageQueryValidationResult(
             query=query,

--- a/snakemake_storage_plugin_sharepoint/provider.py
+++ b/snakemake_storage_plugin_sharepoint/provider.py
@@ -85,7 +85,10 @@ class StorageProvider(StorageProviderBase):
             return StorageQueryValidationResult(
                 query=query,
                 valid=False,
-                reason="path must specify the library and file path (e.g. mssp://library/file.txt or mssp://library/folder/file.txt)",
+                reason=(
+                    "path must specify the library and file path (e.g. "
+                    "mssp://library/file.txt or mssp://library/folder/file.txt)"
+                ),
             )
         return StorageQueryValidationResult(
             query=query,

--- a/snakemake_storage_plugin_sharepoint/provider.py
+++ b/snakemake_storage_plugin_sharepoint/provider.py
@@ -25,8 +25,6 @@ class StorageProvider(StorageProviderBase):
         super().__post_init__()
         if self.settings.site_url is not None:
             self.settings.site_url = self.settings.site_url.rstrip("/")
-        if self.settings.library is not None:
-            self.settings.library = self.settings.library.strip("/")
 
     def rate_limiter_key(self, query: str, operation: Operation) -> Any:
         """Return a key for identifying a rate limiter given a query and an operation.
@@ -43,8 +41,8 @@ class StorageProvider(StorageProviderBase):
         """Return an example query with description for this storage provider."""
         return [
             ExampleQuery(
-                query="file.txt",
-                description="A file URL",
+                query="mssp://library/folder/file.txt",
+                description="A file URL in a SharePoint library.",
                 type=QueryType.INPUT,
             )
         ]
@@ -61,12 +59,18 @@ class StorageProvider(StorageProviderBase):
     @classmethod
     def is_valid_query(cls, query: str) -> StorageQueryValidationResult:
         try:
-            urlparse(f"http://example.com/{query}")
+            parsed = urlparse(query)
         except Exception as e:
             return StorageQueryValidationResult(
                 query=query,
                 valid=False,
                 reason=f"cannot be parsed as URL ({e})",
+            )
+        if not parsed.scheme == "mssp":
+            return StorageQueryValidationResult(
+                query=query,
+                valid=False,
+                reason="scheme must be 'mssp'",
             )
         return StorageQueryValidationResult(
             query=query,

--- a/snakemake_storage_plugin_sharepoint/settings.py
+++ b/snakemake_storage_plugin_sharepoint/settings.py
@@ -110,12 +110,6 @@ class StorageProviderSettings(StorageProviderSettingsBase):
             "env_var": True,
         },
     )
-    library: Optional[str] = dataclasses.field(
-        default=None,
-        metadata={
-            "help": "The folder in the SharePoint site to work with.",
-        },
-    )
     allow_overwrite: bool = dataclasses.field(
         default=False,
         metadata={

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -18,7 +18,7 @@ class TestStorageNoSettings(TestStorageBase):
     __test__ = False
 
     def get_query(self, tmp_path) -> str:
-        return "stable"
+        return "en/stable"
 
     def get_query_not_existing(self, tmp_path) -> str:
         return "this/does/not/exist"
@@ -27,9 +27,7 @@ class TestStorageNoSettings(TestStorageBase):
         return StorageProvider
 
     def get_storage_provider_settings(self) -> Optional[StorageProviderSettingsBase]:
-        return StorageProviderSettings(
-            site_url="https://snakemake.readthedocs.io", library="en"
-        )
+        return StorageProviderSettings(site_url="https://snakemake.readthedocs.io")
 
     def get_example_args(self) -> List[str]:
         return []

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -18,10 +18,10 @@ class TestStorageNoSettings(TestStorageBase):
     __test__ = False
 
     def get_query(self, tmp_path) -> str:
-        return "en/stable"
+        return "mssp://en/stable"
 
     def get_query_not_existing(self, tmp_path) -> str:
-        return "this/does/not/exist"
+        return "mssp://this/does/not/exist"
 
     def get_storage_provider_cls(self) -> Type[StorageProviderBase]:
         return StorageProvider

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -33,6 +33,32 @@ class TestStorageNoSettings(TestStorageBase):
         return []
 
 
-class TestNothing:
-    def test_nothing(self):
-        pass
+def query_is_valid(query: str) -> bool:
+    return StorageProvider.is_valid_query(query).valid
+
+
+def query_is_invalid(query: str) -> bool:
+    return not query_is_valid(query)
+
+
+class TestQueryValidation:
+    def test_query_with_library_and_filename_is_valid(self):
+        assert query_is_valid("mssp://library/filename.txt")
+
+    def test_query_with_library_and_folder_and_filename_is_valid(self):
+        assert query_is_valid("mssp://library/folder/filename.txt")
+
+    def test_empty_query_is_invalid(self):
+        assert query_is_invalid("")
+
+    def test_query_with_no_library_and_no_filename_is_invalid(self):
+        assert query_is_invalid("mssp://")
+
+    def test_query_with_library_and_no_filename_is_invalid(self):
+        assert query_is_invalid("mssp://library/")
+
+    def test_query_with_no_library_is_invalid(self):
+        assert query_is_invalid("mssp://filename.txt")
+
+    def test_query_with_no_schema_invalid(self):
+        assert query_is_invalid("library/filename.txt")


### PR DESCRIPTION
removes `library` setting from the provider and instead extracts it from the query. Also, uses the `mssp://` scheme to mark files are originating from a SharePoint site.